### PR TITLE
B-19459-IAC-UPDATE

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "main" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:${var.cleaner_db_instance_identifier}",
+      # "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:${var.cleaner_db_instance_identifier}",
       "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:${var.cleaner_db_instance_identifier}-*",
     ]
   }


### PR DESCRIPTION
update to remove read permission for the cleaner so it does not attempt to remove snapshots without the proper naming convention, which causes an unauthorized api exception